### PR TITLE
added JSON response format for tournaments & tournaments/:id

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -6,13 +6,19 @@ class TournamentsController < ApplicationController
   # GET /tournaments.json
   def index
     @tournaments = Tournament.all.order(date: :desc)
+    respond_to do |format|
+      format.html
+      format.json {render json: @tournaments.as_json({:only => [:id, :name, :location, :state, :country, :date, :format_id, :version_id, :tournament_type_id, :created_at, :updated_at], :exclude => [:participants]})}
+    end
   end
 
   # GET /tournaments/1
   # GET /tournaments/1.json
   def show
     respond_to do |format|
+      #@tournament = Tournament.where(id:params[:id])
       format.html
+      format.json { render json: @tournament.as_json({:only => [:id, :name, :location, :state, :country, :date, :format_id, :version_id, :tournament_type_id, :created_at, :updated_at], :include => [:participants]})}
       format.csv { send_data  Tournament.where(id:params[:id]).to_csv, filename: "listfortress-#{@tournament.id}.csv"}
     end
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -2,6 +2,10 @@ class Participant < ApplicationRecord
   belongs_to :tournament, counter_cache: true
   attr_accessor :squad_url
 
+  def serializable_hash(options={})
+    super({:only => [:id,:tournament_id,:player_id,:score,:swiss_rank,:top_cut_rank,:mov,:sos,:dropped,:list_points,:list_json]}.merge(options||{}))
+  end
+
   def self.get_xws_from_url(url)
     match = url.match(/raithos.github.io\/(?<query_string>.*)/)
     if match

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -30,6 +30,10 @@ class Tournament < ApplicationRecord
     end
   end
 
+  def serializable_hash(options={})
+    super({}.merge(options || {}))
+  end
+
   def self.to_csv
     header = %w{tournamentName type format date playerName squad score mov sos swiss_rank top_cut_rank}
     CSV.generate(headers: true) do |csv|


### PR DESCRIPTION
Updated tournaments_controller.rb to respond to GET on index and show to format.json and render json. Limited the fields displayed to tournament information for GET tournaments, and including the participant information when the request is for a specific tournament.

Added serializable_hash method to tournament.rb to handle the render json with options.

Added serializable_hash method to participants.rb and limited the response to not include the player name or creation/update dates.