### PR TITLE
Bcp match fix

### DIFF
--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -243,17 +243,14 @@ class Tournament < ApplicationRecord
       player2_points = cells[2].css('span')[2]&.text&.to_i
 
       match = Match.create(round_id: round.id)
-      player1_obj = Participant.find_by(name: player1)
-      if player1_obj.present?
-        match.player1 = player1_obj
-      end
-
+      player1_obj = Participant.find_by(name: player1, tournament_id: id)
+      match.player1 = player1_obj if player1_obj.present?
       match.player1_points = player1_points
-      player2_obj = Participant.find_by(name:player2)
-      if player2_obj.present?
-        match.player2 = player2_obj
-      end
+
+      player2_obj = Participant.find_by(name: player2, tournament_id: id)
+      match.player2 = player2_obj if player2_obj.present?
       match.player2_points = player2_points
+
       if player1_points.to_i > player2_points.to_i
         match.result = 'win'
         match.winner = player1_obj

--- a/lib/tasks/redo_bcp_matches.rake
+++ b/lib/tasks/redo_bcp_matches.rake
@@ -1,14 +1,21 @@
 desc 'Fix BCP Matches that have the wrong participants'
 task redo_bcp_matches: :environment do
-  # There was a bug in the BCP importer that matched Participants by just name instead of name and tournament
+  # There was a bug in the BCP importer that matched Participants 
+  # by just name instead of name and tournament
   # This rake task is designed to go back and fix those matches
-  affected_tournaments = [495,505,510,568,583,648,690,717].freeze
+  affected_tournaments = [495, 505, 510, 568, 583, 648, 690, 717].freeze
 
   def fix_match(match, tournament_id)
+    player1_name = match&.player1&.name
+    player2_name = match&.player2&.name
+    winner_name = match&.winner&.name
 
+    match.player1 = Participant.find_by(name: player1_name, tournament_id: tournament_id)
+    match.player2 = Participant.find_by(name: player2_name, tournament_id: tournament_id)
+    match.winner =  Participant.find_by(name: winner_name, tournament_id: tournament_id)
 
+    match.save
   end
-
 
   affected_tournaments.each do |tournament_id|
     Tournament.find(tournament_id).rounds.each do |round|

--- a/lib/tasks/redo_bcp_matches.rake
+++ b/lib/tasks/redo_bcp_matches.rake
@@ -1,0 +1,20 @@
+desc 'Fix BCP Matches that have the wrong participants'
+task redo_bcp_matches: :environment do
+  # There was a bug in the BCP importer that matched Participants by just name instead of name and tournament
+  # This rake task is designed to go back and fix those matches
+  affected_tournaments = [495,505,510,568,583,648,690,717].freeze
+
+  def fix_match(match, tournament_id)
+
+
+  end
+
+
+  affected_tournaments.each do |tournament_id|
+    Tournament.find(tournament_id).rounds.each do |round|
+      round.matches.each do |match|
+        fix_match(match, tournament_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was a bug in the BCP importer that matched Participants by just name instead of name and tournament. This fixes the importer and adds a task that corrects the matches.