### PR TITLE
Revert to using Uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,10 @@ gem 'puma'
 # Use SCSS for stylesheets
 gem 'sassc-rails'
 # Use closure-compiler as compressor for JavaScript assets
-gem 'closure-compiler'
+# gem 'closure-compiler'
 
 # Uglifier produced bad JS that resulted in errors in production.
-# gem 'uglifier'
+gem 'uglifier'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'duktape'
 # Use CoffeeScript for .coffee assets and views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (3.0.0)
-    closure-compiler (1.1.14)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -250,6 +249,8 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
     unicode_utils (1.4.0)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -281,7 +282,6 @@ DEPENDENCIES
   bootstrap_form
   byebug
   capybara (>= 2.15)
-  closure-compiler
   coffee-rails (~> 4.2)
   connection_pool
   country_select
@@ -302,6 +302,7 @@ DEPENDENCIES
   sassc-rails
   selenium-webdriver
   turbolinks (~> 5)
+  uglifier
   web-console (>= 3.3.0)
   webdrivers
   will_paginate (~> 3.1.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.js_compressor = :closure
   # config.assets.css_compressor = :sass
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,8 +23,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  # config.assets.js_compressor = :uglifier
-  config.assets.js_compressor = :closure
+  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :closure
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
closure-compiler wouldn't work with ES6 code and my previous problems with Uglifier seem to have been fixed.